### PR TITLE
update MarkupSafe version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ Flask-WTF==0.14.2
 itsdangerous==0.24
 Jinja2==2.10
 Mako==1.0.7
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 PyMySQL==0.8.0
 python-dateutil==2.6.1
 python-editor==1.0.3


### PR DESCRIPTION
fix for error on pip install 

https://github.com/pallets/markupsafe/issues/57#issuecomment-597105876